### PR TITLE
change overlay position

### DIFF
--- a/webapp/image/index.html
+++ b/webapp/image/index.html
@@ -133,7 +133,7 @@
 <script src="files/js/jquery.plainoverlay.min.js"></script>
 <script>
     $(function () {
-        $('body').plainOverlay('show');
+        $('.content-wrapper').plainOverlay('show');
     })
 </script>
 


### PR DESCRIPTION
## Task description

This change places the overlay in a more prominent position to indicate that we are waiting to load the actual content and not the surrounding components. This is important because it indicates to the user that he is going to be receiving the initialized page in the content-wrapper area. It seems strange when the description text of this pull request is much larger than the actual content of it, but a thorough explanation is required so that the particular change can be accurately reflected in an informative manner to make sure a contributor that may want to investigate the contents of a pull request, isn't forced to go through all the code, to figure out what exactly is being achieved through those aforementioned changes. Thus this pull request description adequately illustrates the methodical approach and reasoning that was used in order to achieve the utmost efficiency in presenting to the user, the correct signal so he can be reassured that his service-vm is being initialized. 
## Implementation details

The part of the code that was changed is written in HyperText Markup Language also known as html. The specific library (jquery) that is used in the change is part of a web programming language (javascipt). The dollar ( $(...) ) notation is used to select the element that is going to have the loading overlay triggered on top of it. In this patch, we changed the selection of the whole `body` element for the class `.content-wrapper`, which is the container inside the Admin-LTE interface. 
## TODO
- [x] Investigate html patterns used to achieve current result
- [x] Investigate the latest web technologies that can be utilized to achieve the requirement
- [x] Experiment with the existing examples of the plainOverlay library
- [x] Change our implementation case for better user understanding
